### PR TITLE
use BTreeMap instead of Hash

### DIFF
--- a/packages/neutron-std/src/types/slinky/marketmap/v1.rs
+++ b/packages/neutron-std/src/types/slinky/marketmap/v1.rs
@@ -120,7 +120,7 @@ pub struct MarketMap {
     /// Markets is the full list of tickers and their associated configurations
     /// to be stored on-chain.
     #[prost(map = "string, message", tag = "1")]
-    pub markets: ::std::collections::HashMap<::prost::alloc::string::String, Market>,
+    pub markets: ::std::collections::BTreeMap<::prost::alloc::string::String, Market>,
 }
 /// Params defines the parameters for the x/marketmap module.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -388,7 +388,7 @@ pub struct MsgUpsertMarketsResponse {
     /// updated.
     /// Deprecated: This field will be empty in all responses.
     #[prost(map = "string, bool", tag = "1")]
-    pub market_updates: ::std::collections::HashMap<::prost::alloc::string::String, bool>,
+    pub market_updates: ::std::collections::BTreeMap<::prost::alloc::string::String, bool>,
 }
 /// MsgCreateMarkets defines a message carrying a payload for creating markets in
 /// the x/marketmap module.


### PR DESCRIPTION
### Problem: Non-Deterministic Responses in `Slinky MarketMap` Query

The `Slinky MarketMap` query uses `HashMap` for the `markets` field, which does not guarantee consistent iteration order. This results in non-deterministic responses, as the order of keys can vary across executions or validators due to `HashMap`'s reliance on randomized hashing.

#### Impact:
1. **State Divergence**:
   - Validators processing `markets` in different orders may produce different state updates, causing consensus failures.
2. **Gas Variability**:
   - Non-deterministic storage access can lead to inconsistent gas usage.
3. **Serialization Mismatch**:
   - Protobuf maps treat keys as unordered, but inconsistent serialization caused by `HashMap` iteration order can lead to divergent `AppHash` and `LastResultsHash`.

---

### Solution: Use `BTreeMap`

Replacing `HashMap` with `BTreeMap` resolves these issues:
- **Consistent Order**: `BTreeMap` ensures keys are iterated in lexicographical order, producing deterministic responses across validators.
- **Protobuf Compatibility**: Protobuf maps remain compatible with `BTreeMap`, maintaining the same structure and format.
- **Eliminates Non-Determinism**: Validators will always process and serialize `markets` in the same order, ensuring consensus stability.

This change is critical to ensuring deterministic behavior in the `Slinky MarketMap` query and preventing potential consensus-breaking issues.
